### PR TITLE
feat: add .aider* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # Optionally, ignore auto.tfvars files if you want to keep them out of version control
 *.auto.tfvars
+.aider*


### PR DESCRIPTION
Ignore all files starting with .aider to keep Aider specific
configuration out of version control. This prevents unwanted
tracking of local development setup.