### PR TITLE
feat: Optimize Zabbix agent cloud-config and add steps

### DIFF
--- a/hetzner.tf
+++ b/hetzner.tf
@@ -162,6 +162,16 @@ output "next_steps" {
     ssh root@${hcloud_server.Zabbix-Agents[0].ipv4_address}
   7. Check the Zabbix Agent Docker container:
     docker ps | grep zabbix-agent
+  8. Add the Zabbix Agent to the Zabbix Server:
+    Go to Data collection -> Hosts or Monitoring -> Hosts
+    Click on Create host to the right (or on the host name to edit an existing host)
+    Hostname: Zabbix-Agent-0
+    Groups: Linux Servers
+    Agent interfaces: IP Address: ${hcloud_server.Zabbix-Agents[0].ipv4_address}
+    Templates: Template OS Linux
+    Agent: Zabbix Agent
+    Save
+    For more information: https://www.zabbix.com/documentation/current/en/manual/config/hosts/host
   EOT
 
   description = "Next steps to configure the Zabbix Server and Agent"

--- a/zabbix-agent-cloud-config.yml
+++ b/zabbix-agent-cloud-config.yml
@@ -1,5 +1,4 @@
 #cloud-config
-
 # This file is a template. The following variables will be replaced by Terraform:
 # ${ip_address} - The IP address of the Zabbix server
 # ${hostname} - The hostname of this Zabbix agent
@@ -7,16 +6,6 @@
 # Update and upgrade the system
 package_update: true
 package_upgrade: true
-
-# Start Docker service
-runcmd:
-  # Install docker
-  - install -m 0755 -d /etc/apt/keyrings
-  - curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
-  - chmod a+r /etc/apt/keyrings/docker.asc
-  - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
-  - apt-get update
-  - apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
 # Create Zabbix agent configuration file
 write_files:
@@ -26,11 +15,36 @@ write_files:
       ServerActive=${ip_address}
       Hostname=${hostname}
 
+# Install Docker and run Zabbix agent
+runcmd:
+  # Install Docker
+  - install -m 0755 -d /etc/apt/keyrings
+  - |
+    curl -fsSL https://download.docker.com/linux/debian/gpg \
+      -o /etc/apt/keyrings/docker.asc
+  - chmod a+r /etc/apt/keyrings/docker.asc
+  - |
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+      https://download.docker.com/linux/debian \
+      $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+      tee /etc/apt/sources.list.d/docker.list > /dev/null
+  - apt-get update
+  - |
+    apt-get install -y \
+      docker-ce \
+      docker-ce-cli \
+      containerd.io \
+      docker-buildx-plugin \
+      docker-compose-plugin
+
   # Run Zabbix agent Docker container
-  - docker run -d --name zabbix-agent \
-    --restart unless-stopped \
-    --network host \
-    -e ZBX_HOSTNAME="${hostname}" \
-    -e ZBX_SERVER_HOST="${ip_address}" \
-    -v /etc/zabbix/zabbix_agent2.conf:/etc/zabbix/zabbix_agent2.conf \
-    zabbix/zabbix-agent2:latest
+  - |
+    docker run -d \
+      --name zabbix-agent \
+      --restart unless-stopped \
+      --network host \
+      -e ZBX_HOSTNAME="${hostname}" \
+      -e ZBX_SERVER_HOST="${ip_address}" \
+      -v /etc/zabbix/zabbix_agent2.conf:/etc/zabbix/zabbix_agent2.conf \
+      zabbix/zabbix-agent2:latest

--- a/zabbix-config.yml
+++ b/zabbix-config.yml
@@ -18,7 +18,7 @@ runcmd:
   - git clone https://github.com/zabbix/zabbix-docker.git
   - cd zabbix-docker
   - git checkout 7.0
-  - docker compose -f ./docker-compose_v3_alpine_mysql_latest.yaml up -d
+  - docker compose -f ./docker-compose_v3_alpine_mysql_latest.yaml --profile full up -d
   # Wait for Zabbix to start (sleep for 2 minutes)
   - sleep 120
   # Secure SSH


### PR DESCRIPTION
Optimize Zabbix agent cloud-config by moving Docker installation
to runcmd section and formatting commands for better readability.
Add steps to Terraform output for adding the Zabbix agent to the
Zabbix server. Update docker-compose command to use --profile full
flag.